### PR TITLE
Add Ctrl-S shortcut to copy the selected item's path

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ C-e:
     go to `~` or `/`
 C-a:
     bring up a prompt for creating files/directories (try qwer/asdf/zx)
+C-s:
+    copy the selected item's path
 Tab:
     select an entry. if a file, open, if a directory, enter
 Enter:
@@ -53,5 +55,5 @@ Backspace:
 **`plans**
 
 - [ ] (C-h or C-b), (C-l or C-f) is up and down direcectories
-- [ ] C-s copies the selected item's path
+- [x] C-s copies the selected item's path
 - [ ] retain the last selection when going between directories

--- a/main.go
+++ b/main.go
@@ -156,6 +156,10 @@ func main() {
 			}
 			switch ev.Key() {
 
+			case tcell.KeyCtrlS:
+				if selectedPath := state.SelectedPath(); selectedPath != "" {
+					screen.SetClipboard([]byte(selectedPath))
+				}
 			case tcell.KeyCtrlO:
 				var selectedEntry os.DirEntry
 				if len(state.Results) > 0 {
@@ -655,6 +659,15 @@ func (s *State) MoveCursor(n int) {
 //
 // fs & search
 //
+
+func (s *State) SelectedPath() string {
+	list := s.CurrentList()
+	if len(list) == 0 || s.Selected < 0 || s.Selected >= len(list) {
+		return ""
+	}
+
+	return path.Join(s.Pwd, list[s.Selected])
+}
 
 func (s *State) Select() string {
 	var list []os.DirEntry


### PR DESCRIPTION
Adds a 'Ctrl-s' shortcut that copies the selected file or directory's absolute path using tcell's clipboard support.