### PR TITLE
add missing things from TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ C-a:
     bring up a prompt for creating files/directories (try qwer/asdf/zx)
 C-s:
     copy the selected item's path
-Tab:
-    select an entry. if a file, open, if a directory, enter
+C-h, C-b:
+    go up a directory
+Tab, C-l, C-f:
+    select an entry. if a file, open, if a directory, enter (go down)
 Enter:
     cd to current/selected directory
 Backspace:
@@ -54,6 +56,6 @@ Backspace:
 
 **`plans**
 
-- [ ] (C-h or C-b), (C-l or C-f) is up and down direcectories
+- [x] (C-h or C-b), (C-l or C-f) is up and down direcectories
 - [x] C-s copies the selected item's path
-- [ ] retain the last selection when going between directories
+- [x] retain the last selection when going between directories

--- a/main.go
+++ b/main.go
@@ -44,6 +44,8 @@ type State struct {
 	Selected int
 	TopIndex int
 
+	LastSel map[string]string // remembers the cursor per dir
+
 	ActivePrompt Prompt
 }
 
@@ -252,7 +254,10 @@ func main() {
 				}
 			case tcell.KeyEnter:
 				quit_on_pwd()
-			case tcell.KeyBackspace, tcell.KeyBackspace2, tcell.KeyCtrlB:
+			// KeyCtrlH is the same code as backspace, so real backspace is KeyBackspace2
+			case tcell.KeyCtrlH, tcell.KeyCtrlB:
+				state.upDir()
+			case tcell.KeyBackspace2:
 				state.backspace(false)
 			case tcell.KeyCtrlW:
 				state.backspace(true)
@@ -524,13 +529,17 @@ func (state *State) DrawFiles() {
 // input & ux
 //
 
+func (s *State) upDir() {
+	splitPwd := strings.Split(strings.TrimSuffix(s.Pwd, "/"), "/")
+	if len(splitPwd) > 1 {
+		newPwd := strings.Join(splitPwd[:len(splitPwd)-1], "/")
+		s.SwitchDir(fmt.Sprint("/", newPwd))
+	}
+}
+
 func (s *State) backspace(full_word bool) {
 	if len(s.Input) < 1 {
-		splitPwd := strings.Split(strings.TrimSuffix(s.Pwd, "/"), "/")
-		if len(splitPwd) > 1 {
-			newPwd := strings.Join(splitPwd[:len(splitPwd)-1], "/")
-			s.SwitchDir(fmt.Sprint("/", newPwd))
-		}
+		s.upDir()
 		return
 	}
 
@@ -700,10 +709,19 @@ func (s *State) SwitchDir(where string) error {
 		return fmt.Errorf("must provide an absolute path")
 	}
 
+	// remember where the cursor was in the dir we're leaving
+	if s.LastSel == nil {
+		s.LastSel = make(map[string]string)
+	}
+	if list := s.CurrentList(); len(list) > 0 && s.Selected < len(list) {
+		s.LastSel[s.Pwd] = list[s.Selected]
+	}
+
 	s.Pwd = cleanPath + "/"
 
 	s.Input = ""
 	s.Selected = 0
+	s.TopIndex = 0
 	s.Results = nil
 
 	files, err := os.ReadDir(s.Pwd)
@@ -712,6 +730,20 @@ func (s *State) SwitchDir(where string) error {
 	}
 
 	s.Files = files
+
+	// retain the last selection when coming back to this dir
+	if name, ok := s.LastSel[s.Pwd]; ok {
+		for i, f := range files {
+			if f.Name() == name {
+				s.Selected = i
+				break
+			}
+		}
+		visibleHeight := height - 3
+		if s.Selected >= visibleHeight {
+			s.TopIndex = s.Selected - visibleHeight + 1
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Features

Saw the todo list in the README and thought i'd try to complete them for you.
- added the '(C-h or C-b), (C-l or C-f)'
- retain the last selection moving between directories

## Tested
go version go1.26.6 darwin/arm64
