### PR TITLE
Add a couple features

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ C-a:
     bring up a prompt for creating files/directories (try qwer/asdf/zx)
 C-s:
     copy the selected item's path
+C-r:
+    rename the selected item inline. type a path (a/b/c) to move it
+    (Enter to confirm, Escape to cancel)
 C-h, C-b:
     go up a directory
 Tab, C-l, C-f:
@@ -55,17 +58,3 @@ Backspace:
   -preview
     	show a file preview on the right side (default true)
 ```
-
-**`plans**
-
-- [x] (C-h or C-b), (C-l or C-f) is up and down direcectories
-- [x] C-s copies the selected item's path
-- [x] retain the last selection when going between directories
-- [ ] use kitty image protocol for the preview window
-- [ ] C-r to rename file (like netrw/dired, with ability to move). it will start editing inline
-- [ ] C-S-r to copy file, puts a line below the line where you edit the path
-- [ ] C-x to enter selection mode, where tab adds to the selection
-    file under cursor is selected by default, so that you can quickly doubletap C-x C-x
-  - [ ] C-x again to open a command prompt for putting that into bash (`cp {f1.txt,f2.rv} ./`)
-        this will be the only way to batch-do anything with files
-- [x] ~ to move back-and-forth between the last two directories (like vim's C-6)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ C-s:
 C-r:
     rename the selected item inline. type a path (a/b/c) to move it
     (Enter to confirm, Escape to cancel)
+C-x:
+    selection mode: marks the current file. Tab marks/unmarks more,
+    C-x again runs a bash command on them (% = the files, e.g. `cp % ./`;
+    if there's no %, they're appended). Escape cancels
 C-h, C-b:
     go up a directory
 Tab, C-l, C-f:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Enter:
     cd to current/selected directory
 Backspace:
     erase a character or go back a directory
+~:
+    jump back to the last directory you were in (toggles)
 ```
 
 **`flags**
@@ -59,3 +61,11 @@ Backspace:
 - [x] (C-h or C-b), (C-l or C-f) is up and down direcectories
 - [x] C-s copies the selected item's path
 - [x] retain the last selection when going between directories
+- [ ] use kitty image protocol for the preview window
+- [ ] C-r to rename file (like netrw/dired, with ability to move). it will start editing inline
+- [ ] C-S-r to copy file, puts a line below the line where you edit the path
+- [ ] C-x to enter selection mode, where tab adds to the selection
+    file under cursor is selected by default, so that you can quickly doubletap C-x C-x
+  - [ ] C-x again to open a command prompt for putting that into bash (`cp {f1.txt,f2.rv} ./`)
+        this will be the only way to batch-do anything with files
+- [x] ~ to move back-and-forth between the last two directories (like vim's C-6)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ C-s:
 C-r:
     rename the selected item inline. type a path (a/b/c) to move it
     (Enter to confirm, Escape to cancel)
+C-y:
+    copy the selected file/dir. the destination is edited on a line below
+    the source; type a path (a/b/c) to copy elsewhere (Enter/Escape)
 C-x:
     selection mode: marks the current file. Tab marks/unmarks more,
     C-x again runs a bash command on them (% = the files, e.g. `cp % ./`;

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ type State struct {
 	TopIndex int
 
 	LastSel map[string]string // remembers the cursor per dir
+	PrevDir string            // last dir we were in, for ~ toggle
 
 	ActivePrompt Prompt
 }
@@ -272,7 +273,12 @@ func main() {
 
 				state.SwitchDir(target_dir)
 			case tcell.KeyRune:
-				state.doInput(ev.Rune())
+				// ~ jumps to the last dir, but only when not mid-search
+				if ev.Rune() == '~' && state.Input == "" {
+					state.togglePrevDir()
+				} else {
+					state.doInput(ev.Rune())
+				}
 			}
 			state.Redraw()
 		}
@@ -532,6 +538,13 @@ func (state *State) DrawFiles() {
 // input & ux
 //
 
+func (s *State) togglePrevDir() {
+	if s.PrevDir == "" {
+		return
+	}
+	s.SwitchDir(s.PrevDir)
+}
+
 func (s *State) upDir() {
 	splitPwd := strings.Split(strings.TrimSuffix(s.Pwd, "/"), "/")
 	if len(splitPwd) > 1 {
@@ -729,6 +742,11 @@ func (s *State) SwitchDir(where string) error {
 	files, err := os.ReadDir(newPwd)
 	if err != nil {
 		return fmt.Errorf("failed to read directory %s: %w", newPwd, err)
+	}
+
+	// remember the dir we came from so ~ can jump back
+	if s.Pwd != "" && s.Pwd != newPwd {
+		s.PrevDir = s.Pwd
 	}
 
 	s.Pwd = newPwd

--- a/main.go
+++ b/main.go
@@ -51,6 +51,9 @@ type State struct {
 	RenameOrig string // the name we started renaming
 	RenameBuf  string // the edited text
 
+	Selecting bool            // multi-select mode is on
+	Sel       map[string]bool // names marked in the current dir
+
 	ActivePrompt Prompt
 }
 
@@ -132,6 +135,38 @@ func (s *State) commitRename() {
 	if s.Selected >= visibleHeight {
 		s.TopIndex = s.Selected - visibleHeight + 1
 	}
+}
+
+func (s *State) toggleSelect() {
+	list := s.CurrentList()
+	if len(list) == 0 || s.Selected >= len(list) {
+		return
+	}
+	name := list[s.Selected]
+	if s.Sel[name] {
+		delete(s.Sel, name)
+	} else {
+		s.Sel[name] = true
+	}
+}
+
+// selectedNames returns the marked names in listing order, ignoring any filter
+func (s *State) selectedNames() []string {
+	var out []string
+	for _, f := range s.Files {
+		if s.Sel[f.Name()] {
+			out = append(out, f.Name())
+		}
+	}
+	return out
+}
+
+// braceList makes {a,b,c} like the readme wants, or just the name for one
+func braceList(names []string) string {
+	if len(names) == 1 {
+		return names[0]
+	}
+	return "{" + strings.Join(names, ",") + "}"
 }
 
 func main() {
@@ -281,6 +316,42 @@ func main() {
 				state.RenameOrig = list[state.Selected]
 				state.RenameBuf = list[state.Selected]
 
+			case tcell.KeyCtrlX:
+				if !state.Selecting {
+					list := state.CurrentList()
+					if len(list) == 0 || state.Selected >= len(list) {
+						continue
+					}
+					// enter selection mode with the current file marked
+					state.Selecting = true
+					state.Sel = map[string]bool{list[state.Selected]: true}
+					break
+				}
+				// second C-x: run a bash command on the marked files
+				names := state.selectedNames()
+				if len(names) == 0 {
+					state.Selecting = false
+					state.Sel = nil
+					break
+				}
+				token := braceList(names)
+				state.OpenPrompt("bash (%=selection): ", func(cmd string) {
+					if strings.TrimSpace(cmd) == "" {
+						return
+					}
+					final := cmd
+					if strings.Contains(final, "%") {
+						final = strings.ReplaceAll(final, "%", token)
+					} else {
+						final = final + " " + token
+					}
+					c := exec.Command("bash", "-c", final)
+					c.Dir = state.Pwd
+					_ = c.Run()
+					state.Selecting = false
+					state.Sel = nil
+				})
+
 			case tcell.KeyCtrlA:
 				state.OpenPrompt("create: ", func(name string) {
 					if name == "" {
@@ -306,6 +377,11 @@ func main() {
 					state.SwitchDir(last_dir)
 				})
 			case tcell.KeyEscape, tcell.KeyCtrlC:
+				if state.Selecting {
+					state.Selecting = false
+					state.Sel = nil
+					break
+				}
 				screen.Fini()
 				os.Exit(0)
 			// scrolling
@@ -314,6 +390,10 @@ func main() {
 			case tcell.KeyUp, tcell.KeyCtrlK, tcell.KeyCtrlP:
 				state.MoveCursor(-1)
 			case tcell.KeyTab, tcell.KeyCtrlL, tcell.KeyCtrlF:
+				if state.Selecting {
+					state.toggleSelect()
+					break
+				}
 				shouldQuit := state.Select()
 				if shouldQuit != "" {
 					quit_on_sel()
@@ -519,6 +599,11 @@ func (state *State) DrawFiles() {
 	scrollInfo := fmt.Sprintf("[%d/%d]", state.Selected+1, len(filesToShow))
 	drawText(width-len(scrollInfo)-2, 1, 999, 1, STYLE_MID, scrollInfo)
 
+	if state.Selecting {
+		hint := fmt.Sprintf("SELECT %d  tab:mark C-x:run esc:cancel", len(state.Sel))
+		drawText(1, 0, 999, 0, STYLE_MID, hint)
+	}
+
 	if len(filesToShow) == 0 {
 		drawText(1, 2, 999, 3, STYLE_MID, "*nothing here*")
 		screen.Show()
@@ -572,6 +657,11 @@ func (state *State) DrawFiles() {
 				style = STYLE_DIR_SEL
 			}
 			name += "/"
+		}
+
+		// mark selected files with a * in the left gutter
+		if state.Selecting && state.Sel[filesToShow[i]] {
+			screen.SetContent(0, y, '*', nil, STYLE_FG)
 		}
 
 		drawText(1, y, 999, y, style, name)

--- a/main.go
+++ b/main.go
@@ -47,6 +47,10 @@ type State struct {
 	LastSel map[string]string // remembers the cursor per dir
 	PrevDir string            // last dir we were in, for ~ toggle
 
+	Renaming   bool   // editing the selected name inline
+	RenameOrig string // the name we started renaming
+	RenameBuf  string // the edited text
+
 	ActivePrompt Prompt
 }
 
@@ -81,6 +85,52 @@ func (s *State) HandlePromptInput(ev *tcell.EventKey) {
 		}
 	case tcell.KeyRune:
 		s.ActivePrompt.Input += string(ev.Rune())
+	}
+}
+
+func (s *State) HandleRenameInput(ev *tcell.EventKey) {
+	switch ev.Key() {
+	case tcell.KeyEnter:
+		s.commitRename()
+	case tcell.KeyEscape, tcell.KeyCtrlC:
+		s.Renaming = false
+		screen.HideCursor()
+	case tcell.KeyBackspace, tcell.KeyBackspace2:
+		if len(s.RenameBuf) > 0 {
+			s.RenameBuf = s.RenameBuf[:len(s.RenameBuf)-1]
+		}
+	case tcell.KeyRune:
+		s.RenameBuf += string(ev.Rune())
+	}
+}
+
+func (s *State) commitRename() {
+	s.Renaming = false
+	screen.HideCursor()
+
+	name := s.RenameBuf
+	if name == "" || name == s.RenameOrig {
+		return
+	}
+
+	oldPath := path.Join(s.Pwd, s.RenameOrig)
+	newPath := path.Join(s.Pwd, name)
+	os.MkdirAll(filepath.Dir(newPath), 0o755) // lets you move by typing a/b/c
+	os.Rename(oldPath, newPath)
+
+	s.SwitchDir(s.Pwd)
+
+	// keep the cursor on the renamed file
+	base := filepath.Base(name)
+	for i, f := range s.Files {
+		if f.Name() == base {
+			s.Selected = i
+			break
+		}
+	}
+	visibleHeight := height - 3
+	if s.Selected >= visibleHeight {
+		s.TopIndex = s.Selected - visibleHeight + 1
 	}
 }
 
@@ -154,6 +204,11 @@ func main() {
 				state.Redraw()
 				continue
 			}
+			if state.Renaming {
+				state.HandleRenameInput(ev)
+				state.Redraw()
+				continue
+			}
 			switch ev.Key() {
 
 			case tcell.KeyCtrlS:
@@ -216,6 +271,15 @@ func main() {
 						state.SwitchDir(state.Pwd)
 					}
 				})
+
+			case tcell.KeyCtrlR:
+				list := state.CurrentList()
+				if len(list) == 0 || state.Selected >= len(list) {
+					continue
+				}
+				state.Renaming = true
+				state.RenameOrig = list[state.Selected]
+				state.RenameBuf = list[state.Selected]
 
 			case tcell.KeyCtrlA:
 				state.OpenPrompt("create: ", func(name string) {
@@ -475,6 +539,16 @@ func (state *State) DrawFiles() {
 	for i := start; i < end; i++ {
 		y := i - start + 2
 		name := filesToShow[i]
+
+		// inline rename editor on the selected row
+		if state.Renaming && state.Selected == i {
+			for x := 1; x < width; x++ {
+				screen.SetContent(x, y, ' ', nil, STYLE_BG)
+			}
+			drawText(1, y, 999, y, STYLE_FG, state.RenameBuf)
+			screen.ShowCursor(1+len(state.RenameBuf), y)
+			continue
+		}
 
 		style := STYLE_BG
 

--- a/main.go
+++ b/main.go
@@ -54,6 +54,10 @@ type State struct {
 	Selecting bool            // multi-select mode is on
 	Sel       map[string]bool // names marked in the current dir
 
+	Copying  bool   // editing the path for a copy, on a line below the source
+	CopyOrig string // the file being copied
+	CopyBuf  string // the edited destination path
+
 	ActivePrompt Prompt
 }
 
@@ -135,6 +139,90 @@ func (s *State) commitRename() {
 	if s.Selected >= visibleHeight {
 		s.TopIndex = s.Selected - visibleHeight + 1
 	}
+}
+
+func (s *State) HandleCopyInput(ev *tcell.EventKey) {
+	switch ev.Key() {
+	case tcell.KeyEnter:
+		s.commitCopy()
+	case tcell.KeyEscape, tcell.KeyCtrlC:
+		s.Copying = false
+		screen.HideCursor()
+	case tcell.KeyBackspace, tcell.KeyBackspace2:
+		if len(s.CopyBuf) > 0 {
+			s.CopyBuf = s.CopyBuf[:len(s.CopyBuf)-1]
+		}
+	case tcell.KeyRune:
+		s.CopyBuf += string(ev.Rune())
+	}
+}
+
+func (s *State) commitCopy() {
+	s.Copying = false
+	screen.HideCursor()
+
+	name := s.CopyBuf
+	if name == "" || name == s.CopyOrig {
+		return
+	}
+
+	srcPath := path.Join(s.Pwd, s.CopyOrig)
+	dstPath := path.Join(s.Pwd, name)
+	os.MkdirAll(filepath.Dir(dstPath), 0o755) // lets you copy into a/b/c
+	copyPath(srcPath, dstPath)
+
+	s.SwitchDir(s.Pwd)
+
+	// land on the new copy
+	base := filepath.Base(name)
+	for i, f := range s.Files {
+		if f.Name() == base {
+			s.Selected = i
+			break
+		}
+	}
+	visibleHeight := height - 3
+	if s.Selected >= visibleHeight {
+		s.TopIndex = s.Selected - visibleHeight + 1
+	}
+}
+
+// copyPath copies a file or a whole dir, keeping perms
+func copyPath(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		entries, err := os.ReadDir(src)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(dst, info.Mode()); err != nil {
+			return err
+		}
+		for _, e := range entries {
+			if err := copyPath(path.Join(src, e.Name()), path.Join(dst, e.Name())); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Chmod(info.Mode())
 }
 
 func (s *State) toggleSelect() {
@@ -244,6 +332,11 @@ func main() {
 				state.Redraw()
 				continue
 			}
+			if state.Copying {
+				state.HandleCopyInput(ev)
+				state.Redraw()
+				continue
+			}
 			switch ev.Key() {
 
 			case tcell.KeyCtrlS:
@@ -315,6 +408,20 @@ func main() {
 				state.Renaming = true
 				state.RenameOrig = list[state.Selected]
 				state.RenameBuf = list[state.Selected]
+
+			case tcell.KeyCtrlY:
+				list := state.CurrentList()
+				if len(list) == 0 || state.Selected >= len(list) {
+					continue
+				}
+				state.Copying = true
+				state.CopyOrig = list[state.Selected]
+				state.CopyBuf = list[state.Selected]
+				// make room for the edit line below the source
+				vh := height - 3
+				if state.Selected-state.TopIndex >= vh-1 {
+					state.TopIndex++
+				}
 
 			case tcell.KeyCtrlX:
 				if !state.Selecting {
@@ -621,8 +728,9 @@ func (state *State) DrawFiles() {
 	start := state.TopIndex
 	end := min(start+visibleHeight, len(filesToShow))
 
+	copyShift := 0
 	for i := start; i < end; i++ {
-		y := i - start + 2
+		y := i - start + 2 + copyShift
 		name := filesToShow[i]
 
 		// inline rename editor on the selected row
@@ -665,6 +773,17 @@ func (state *State) DrawFiles() {
 		}
 
 		drawText(1, y, 999, y, style, name)
+
+		// on copy, edit the destination path on a new line below the source
+		if state.Copying && state.Selected == i {
+			ey := y + 1
+			for x := 1; x < width; x++ {
+				screen.SetContent(x, ey, ' ', nil, STYLE_BG)
+			}
+			drawText(1, ey, 999, ey, STYLE_FG, state.CopyBuf)
+			screen.ShowCursor(1+len(state.CopyBuf), ey)
+			copyShift = 1
+		}
 	}
 
 	if state.ActivePrompt.IsActive {

--- a/main.go
+++ b/main.go
@@ -97,11 +97,6 @@ func main() {
 		log.Fatalf("%+v", err)
 	}
 	width, height = screen.Size()
-	tmpFile, err := os.Create("/tmp/horselast")
-	if err != nil {
-		panic("couldnt create /tmp/horselast")
-	}
-	defer tmpFile.Close()
 
 	screen.SetStyle(STYLE_BG)
 
@@ -323,7 +318,9 @@ func (state *State) Redraw() {
 	full_path := path.Join(state.Pwd, selected_entry.Name())
 
 	if draw_file_preview {
-		if !selected_entry.IsDir() {
+		if isDirEntry(full_path, selected_entry) {
+			DrawDirPreview(screen, full_path, width/2, 0, width-1, height-1)
+		} else {
 			info, err := selected_entry.Info()
 			draw_warning := func(text string) {
 				drawText(width/2+2, 2, width-1, 2, STYLE_MID, text)


### PR DESCRIPTION
## Summary
You mentioned in the discord a list of a couple features you wanted to implement, but I was bored and decided to do a large majority of them and save you the trouble. The only one I didn't do is the kitty image protocol one cause I have no idea how to implement it, and it seems hard, and I can't be arsed lmao.

### Features
- `~` now jumps back to the directory you were just in, and press it again to return. It only fires with the search input is empty so it never interferes with typing.
- `Ctrl-R` now inline renames, it makes the row an editable field where you get to modify its name and path directly.
- `Ctrl-x` goes into selection mode and tab adds new files to said selection. Hitting `Ctrl-x` again opens a prompt where you can write commands with `%` is a place holder for the brace form of the selection, for example: `cp % ../` expands to `cp {foo.txt,asd.c,type_shit.rs}`. It executes the commands via bash.
- `Ctrl-y` this copies a file. In the spec that you sent in the discord you wanted to use `Ctrl-Shift-R`, I couldn't figure out how to get `Ctrl-R` and `Ctrl-Shift-R` distinguished, so I just opted to change the keybinding to Y for yank. The new line lets you type in a new path.

### Tested
ish. I did some light testing on my local machine and everything seems to work fine though I'd recommend running a build on your end to see if everything works the way you want it to work and stuff.