### PR TITLE
Made the left and right arrow keys work like backspace/enter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ C-x:
     selection mode: marks the current file. Tab marks/unmarks more,
     C-x again runs a bash command on them (% = the files, e.g. `cp % ./`;
     if there's no %, they're appended). Escape cancels
-C-h, C-b:
+Left, C-h, C-b:
     go up a directory
-Tab, C-l, C-f:
+Tab, Right, C-l, C-f:
     select an entry. if a file, open, if a directory, enter (go down)
 Enter:
     cd to current/selected directory

--- a/main.go
+++ b/main.go
@@ -195,14 +195,14 @@ func HandleKey(ev *tcell.EventKey) {
 		MoveCursor(1)
 	case tcell.KeyUp, tcell.KeyCtrlK, tcell.KeyCtrlP:
 		MoveCursor(-1)
-	case tcell.KeyTab, tcell.KeyCtrlL, tcell.KeyCtrlF:
+	case tcell.KeyTab, tcell.KeyCtrlL, tcell.KeyCtrlF, tcell.KeyRight:
 		selectOrToggle()
 	case tcell.KeyEnter:
 		quitOnPwd()
 	// KeyCtrlH is the same code as backspace, and the actual backspace is KeyBackspace2
 	case tcell.KeyCtrlH, tcell.KeyCtrlB:
 		upDir()
-	case tcell.KeyBackspace2:
+	case tcell.KeyBackspace2, tcell.KeyLeft:
 		backspace(false)
 	case tcell.KeyCtrlW:
 		backspace(true)


### PR DESCRIPTION
I noticed that while you could use the up and down arrows like ```ctrl-j``` and ```ctrl-k``` but the left and right arrows don't conform to that pattern. I am not sure whether this is intentional but I added the mentioned keybindings and updated the ```README.md``` accordingly.