### PR TITLE
Fix Ctrl+A create prompt in empty directories

### DIFF
--- a/main.go
+++ b/main.go
@@ -1302,12 +1302,10 @@ func DrawFiles() {
 
 	if len(filesToShow) == 0 {
 		drawText(1, 2, 999, 3, STYLE_MID, "*nothing here*")
-		screen.Show()
-		return
+	} else {
+		Selected = min(Selected, len(filesToShow)-1)
+		TopIndex = min(TopIndex, Selected)
 	}
-
-	Selected = min(Selected, len(filesToShow)-1)
-	TopIndex = min(TopIndex, Selected)
 
 	visibleHeight := height - reservedRows
 	start := TopIndex


### PR DESCRIPTION
The file list renderer returned early for empty directories, preventing the create prompt from appearing after pressing <C-a>.

Allow rendering to continue so the prompt, cursor, and typed filename remain visible.